### PR TITLE
Sync stakers/delegators

### DIFF
--- a/contracts/sfc/Staker.sol
+++ b/contracts/sfc/Staker.sol
@@ -457,7 +457,7 @@ contract Stakers is Ownable, StakersConstants {
         emit ClaimedValidatorReward(stakerID, pendingRewards, fromEpoch, untilEpoch);
     }
 
-    event PreparedToWithdrawStake(uint256 indexed stakerID);
+    event PreparedToWithdrawStake(uint256 indexed stakerID); // previous name for DeactivatedStake
     event DeactivatedStake(uint256 indexed stakerID);
 
     // deactivate stake, to be able to withdraw later
@@ -471,7 +471,6 @@ contract Stakers is Ownable, StakersConstants {
         stakers[stakerID].deactivatedTime = block.timestamp;
 
         emit DeactivatedStake(stakerID);
-        emit PreparedToWithdrawStake(stakerID);
     }
 
     event WithdrawnStake(uint256 indexed stakerID, uint256 penalty);
@@ -504,7 +503,7 @@ contract Stakers is Ownable, StakersConstants {
         emit WithdrawnStake(stakerID, penalty);
     }
 
-    event PreparedToWithdrawDelegation(address indexed from, uint256 indexed stakerID);
+    event PreparedToWithdrawDelegation(address indexed from, uint256 indexed stakerID); // previous name for DeactivatedDelegation
     event DeactivatedDelegation(address indexed from, uint256 indexed stakerID);
 
     // deactivate delegation, to be able to withdraw later
@@ -523,7 +522,6 @@ contract Stakers is Ownable, StakersConstants {
         }
 
         emit DeactivatedDelegation(from, stakerID);
-        emit PreparedToWithdrawDelegation(from, stakerID);
     }
 
     event WithdrawnDelegation(address indexed from, uint256 indexed stakerID, uint256 penalty);

--- a/contracts/sfc/Staker.sol
+++ b/contracts/sfc/Staker.sol
@@ -591,6 +591,24 @@ contract Stakers is Ownable, StakersConstants {
         _updateCapReachedDate();
         return rewardsAllowed();
     }
+
+    event UpdatedDelegation(address indexed delegator, uint256 indexed oldStakerID, uint256 indexed newStakerID, uint256 amount);
+
+    // syncDelegator updates the delegator data on node, if it differs for some reason
+    function _syncDelegator(address delegator) public {
+        require(delegations[delegator].amount != 0, "delegation doesn't exist");
+        // emit special log for node
+        emit UpdatedDelegation(delegator, delegations[delegator].toStakerID, delegations[delegator].toStakerID, delegations[delegator].amount);
+    }
+
+    event UpdatedStake(uint256 indexed stakerID, uint256 amount, uint256 delegatedMe);
+
+    // syncStaker updates the staker data on node, if it differs for some reason
+    function _syncStaker(uint256 stakerID) public {
+        require(stakers[stakerID].stakeAmount != 0, "staker doesn't exist");
+        // emit special log for node
+        emit UpdatedStake(stakerID, stakers[stakerID].stakeAmount, stakers[stakerID].delegatedMe);
+    }
 }
 
 contract TestStakers is Stakers {

--- a/contracts/sfc/Staker.sol
+++ b/contracts/sfc/Staker.sol
@@ -457,7 +457,7 @@ contract Stakers is Ownable, StakersConstants {
         emit ClaimedValidatorReward(stakerID, pendingRewards, fromEpoch, untilEpoch);
     }
 
-    event PreparedToWithdrawStake(uint256 indexed stakerID);
+    event DeactivatedStake(uint256 indexed stakerID);
 
     // deactivate stake, to be able to withdraw later
     function prepareToWithdrawStake() external {
@@ -469,7 +469,7 @@ contract Stakers is Ownable, StakersConstants {
         stakers[stakerID].deactivatedEpoch = currentEpoch();
         stakers[stakerID].deactivatedTime = block.timestamp;
 
-        emit PreparedToWithdrawStake(stakerID);
+        emit DeactivatedStake(stakerID);
     }
 
     event WithdrawnStake(uint256 indexed stakerID, uint256 penalty);
@@ -502,7 +502,7 @@ contract Stakers is Ownable, StakersConstants {
         emit WithdrawnStake(stakerID, penalty);
     }
 
-    event PreparedToWithdrawDelegation(address indexed from, uint256 indexed stakerID);
+    event DeactivatedDelegation(address indexed from, uint256 indexed stakerID);
 
     // deactivate delegation, to be able to withdraw later
     function prepareToWithdrawDelegation() external {
@@ -519,7 +519,7 @@ contract Stakers is Ownable, StakersConstants {
             stakers[stakerID].delegatedMe = stakers[stakerID].delegatedMe.sub(delegatedAmount);
         }
 
-        emit PreparedToWithdrawDelegation(from, stakerID);
+        emit DeactivatedDelegation(from, stakerID);
     }
 
     event WithdrawnDelegation(address indexed from, uint256 indexed stakerID, uint256 penalty);

--- a/contracts/sfc/Staker.sol
+++ b/contracts/sfc/Staker.sol
@@ -457,6 +457,7 @@ contract Stakers is Ownable, StakersConstants {
         emit ClaimedValidatorReward(stakerID, pendingRewards, fromEpoch, untilEpoch);
     }
 
+    event PreparedToWithdrawStake(uint256 indexed stakerID);
     event DeactivatedStake(uint256 indexed stakerID);
 
     // deactivate stake, to be able to withdraw later
@@ -470,6 +471,7 @@ contract Stakers is Ownable, StakersConstants {
         stakers[stakerID].deactivatedTime = block.timestamp;
 
         emit DeactivatedStake(stakerID);
+        emit PreparedToWithdrawStake(stakerID);
     }
 
     event WithdrawnStake(uint256 indexed stakerID, uint256 penalty);
@@ -502,6 +504,7 @@ contract Stakers is Ownable, StakersConstants {
         emit WithdrawnStake(stakerID, penalty);
     }
 
+    event PreparedToWithdrawDelegation(address indexed from, uint256 indexed stakerID);
     event DeactivatedDelegation(address indexed from, uint256 indexed stakerID);
 
     // deactivate delegation, to be able to withdraw later
@@ -520,6 +523,7 @@ contract Stakers is Ownable, StakersConstants {
         }
 
         emit DeactivatedDelegation(from, stakerID);
+        emit PreparedToWithdrawDelegation(from, stakerID);
     }
 
     event WithdrawnDelegation(address indexed from, uint256 indexed stakerID, uint256 penalty);


### PR DESCRIPTION
1. Anyone can emit special log to sync stakes on go-lachesis with values in contract. It has dual purpose:
    1. it's needed to fix the issue with ignored PreparedToWithdraw topics in go-lachesis (enough to call once for each validator). See issue https://github.com/Fantom-foundation/go-lachesis/issues/427 .
    2. it's needed for future features related to partial withdrawal and delegation increasing
2. Rename log topics PreparedToWithdrawX to DeactivatedX. There're 2 reasons:
    1. The new name may be more clear for future cases not related to withdrawal
    2. PreparedToWithdrawDelegation were already emitted, and were ignored by go-lachesis node due to the bug. It makes sense to use a new name to differentiate with previous bugged logs. go-lachesis will listen only for DeactivatedDelegation logs for delegators (see Fantom-foundation/go-lachesis#414 ).