### PR TITLE
Separate stakerAddress into sfcAddress and dagAddress

### DIFF
--- a/test/Stakers.js
+++ b/test/Stakers.js
@@ -48,11 +48,13 @@ contract('Staker test', async ([firstStaker, secondStaker, thirdStaker, firstDep
 
         expect((await this.stakers.stakers.call(firstStakerID)).stakeAmount).to.be.bignumber.equal(ether('2.0'));
         expect((await this.stakers.stakers.call(firstStakerID)).createdEpoch).to.be.bignumber.equal(new BN('1'));
-        expect((await this.stakers.stakers.call(firstStakerID)).stakerAddress).to.equal(firstStaker);
+        expect((await this.stakers.stakers.call(firstStakerID)).sfcAddress).to.equal(firstStaker);
+        expect((await this.stakers.stakers.call(firstStakerID)).dagAddress).to.equal(firstStaker);
 
         expect((await this.stakers.stakers.call(secondStakerID)).stakeAmount).to.be.bignumber.equal(ether('1.01'));
         expect((await this.stakers.stakers.call(secondStakerID)).createdEpoch).to.be.bignumber.equal(new BN('1'));
-        expect((await this.stakers.stakers.call(secondStakerID)).stakerAddress).to.equal(secondStaker);
+        expect((await this.stakers.stakers.call(secondStakerID)).sfcAddress).to.equal(secondStaker);
+        expect((await this.stakers.stakers.call(secondStakerID)).dagAddress).to.equal(secondStaker);
     });
 
     it('checking increaseStake function', async () => {


### PR DESCRIPTION
Validator can use different addresses to sign consensus messages (DAG events) and to authenticate himself in the SFC contract. The reasoning:
1. Those addresses may be used on different devices. It's simpler to keep them in secret if private keys aren't shared between multiple devices.
2. With only one address, it's impossible to authenticate in SFC contract using a contract (as an example, a multi sig contract).

Validator can change his SFC address any time (`updateStakerSfcAddress`), but it's prohibited to change DAG address intentionally. First of all, it wouldn't be backward compatible with `go-lachesis`, and second it would make it possible to transfer ownership of a validator between persons, which shouldn't be possible (it would be a betrayal of existing delegators).

After SFC contract upgrade, `_upgradeStakerStorage` should be called for each validator (will be done automatically right after upgrade). Until it's called, validator won't be able to call any functions which require authentication.